### PR TITLE
Cupid Pokemon

### DIFF
--- a/handlers/CupidPokemon.cfc
+++ b/handlers/CupidPokemon.cfc
@@ -21,9 +21,23 @@ component extends="coldbox.system.RestHandler" {
 	 */
 	function getAPokemon( event, rc, prc ) {
 
-		include "/models/pokemon.cfm";
+		//include "/models/pokemon.cfm";
+		pokemon = new models.Pokemon();
+		requestResult = pokemon.getPokemonProperties(rc.pokemonId);
+		
+		if(requestResult)
+		{
+			if(pokemon.checkExist(rc.pokemonId))
+			{
+				pokemon.updatePokemon(rc.pokemonId);
+			}
+			else
+			{
+				pokemon.insertPokemon(rc.pokemonId);
+			}
+		}
 
-		event.getResponse().setData( response );
+		event.getResponse().setData(pokemon.getResponse(rc.pokemonId));
 	}
 
 }

--- a/handlers/CupidPokemon.cfc
+++ b/handlers/CupidPokemon.cfc
@@ -21,7 +21,6 @@ component extends="coldbox.system.RestHandler" {
 	 */
 	function getAPokemon( event, rc, prc ) {
 
-		//include "/models/pokemon.cfm";
 		pokemon = new models.Pokemon();
 		requestResult = pokemon.getPokemonProperties(rc.pokemonId);
 		
@@ -37,7 +36,7 @@ component extends="coldbox.system.RestHandler" {
 			}
 		}
 
-		event.getResponse().setData(pokemon.getResponse(rc.pokemonId));
+		event.getResponse().setData(pokemon.getResponse());
 	}
 
 }

--- a/models/Pokemon.cfc
+++ b/models/Pokemon.cfc
@@ -1,0 +1,115 @@
+component accessors="true" {
+
+  property name="response";
+  property name="pokemon";
+
+  function init()
+  {
+    variables.response = "I've downloaded and stored data for Pokemon with id: ";
+  }
+
+  function getPokemonProperties(pokemonId)
+  {
+    cfhttp(url="https://pokeapi.co/api/v2/pokemon/#pokemonId#", result="result");
+
+    if(result.responseHeader.status_code == 200) {
+      variables.pokemon = DESERIALIZEJSON(result.filecontent);
+      return true;
+    }
+    else {
+      variables.response = "No result found";
+      return false;
+    }
+  }
+
+  function checkExist(required pokemonId)
+  {
+    //check if pokemon id exists in the database already
+    result = queryExecute(
+      "SELECT * FROM CUPIDMEDIA_POKEMON.POKEMON where id = :pokemonId", 
+      {pokemonId: {value: arguments.pokemonId}},
+      {datasource:"pokemon"});
+
+    return result.recordcount eq 1;
+  }
+
+  function insertPokemon()
+  {
+    queryExecute(
+      "INSERT INTO CUPIDMEDIA_POKEMON.POKEMON(ID, SPECIES, URL, HEIGHT)
+       VALUES (
+        :pokemonId,
+        :species,
+        :url,
+        :height
+       )", 
+      {pokemonId: {value: variables.pokemon.id, cfsqltype: "integer"},
+       species: {value: variables.pokemon.species.name, cfsqltype: "varchar"},
+       url: {value: variables.pokemon.species.url, cfsqltype: "varchar"},
+       height: {value: variables.pokemon.height, cfsqltype: "integer"}
+      },
+      {datasource:"pokemon"});
+
+      insertHeldItems();
+  }
+
+  function updatePokemon()
+  {
+    queryExecute(
+      "UPDATE CUPIDMEDIA_POKEMON.POKEMON
+          SET SPECIES = :species,
+              URL = :url,
+              HEIGHT = :height
+        WHERE ID = :pokemonId", 
+      {pokemonId: {value: variables.pokemon.id, cfsqltype: "integer"},
+       species: {value: variables.pokemon.species.name, cfsqltype: "varchar"},
+       url: {value: variables.pokemon.species.url, cfsqltype: "varchar"},
+       height: {value: variables.pokemon.height, cfsqltype: "integer"}
+      },
+      {datasource:"pokemon"});
+
+      updateHeldItems();
+  }
+
+  function insertHeldItems()
+  {
+    variables.pokemon.held_items.each(function (key){
+      queryExecute(
+        "INSERT INTO CUPIDMEDIA_POKEMON.ITEM(POKEMONID, NAME, URL)
+         VALUES (
+          :pokemonId,
+          :itemName,
+          :url
+        )", 
+        {pokemonId: {value: variables.pokemon.id, cfsqltype: "integer"},
+         itemName: {value: arguments.key.item.name, cfsqltype: "varchar"},
+         url: {value: arguments.key.item.url, cfsqltype: "varchar"}
+        },
+        {datasource:"pokemon"});
+    });
+  }
+
+  function updateHeldItems()
+  {
+    queryExecute(
+      "DELETE FROM CUPIDMEDIA_POKEMON.ITEM WHERE POKEMONID = :pokemonId", 
+      {pokemonId: {value: variables.pokemon.id}},
+      {datasource:"pokemon"});
+
+    insertHeldItems();
+  }
+
+  function getResponse()
+  {
+    if(isDefined("variables.pokemon.id"))
+    {
+      returndata = {"message": variables.response & variables.pokemon.id,
+              "pokemon": { "name": variables.pokemon.species.name, "height": variables.pokemon.height, "itemsHeldCount": ArrayLen(variables.pokemon.held_items)}};
+    }
+    else
+    {
+      returndata = {"message": variables.response};
+    }
+    return returndata;
+  }
+}

--- a/tests/specs/integration/PokemonTest.cfc
+++ b/tests/specs/integration/PokemonTest.cfc
@@ -1,0 +1,87 @@
+component extends="coldbox.system.testing.BaseTestCase" {
+
+	/*********************************** LIFE CYCLE Methods ***********************************/
+
+	function beforeAll() {
+		structDelete( application, "cbController" );
+		structDelete( application, "wirebox" );
+		super.beforeAll();
+	}
+
+	function afterAll() {
+		super.afterAll();
+	}
+
+	/*********************************** BDD SUITES ***********************************/
+
+	function run() {
+		describe( "Pokemon", function() {
+			beforeEach( function( currentSpec ) {
+				setup();
+				model = getInstance( "Pokemon" );
+			} );
+
+			it( "can be created", function() {
+				expect( model ).toBeComponent();
+			} );
+      
+			it( "can validate if pokemon id exist in API", function() {
+				var pokemon = model.getPokemonProperties( "Rdasf" );
+				expect( pokemon).toBeFalse();
+			} );
+
+			it( "can check if pokemon already exists in the database", function() {
+				var exists = model.checkExist( 35 );
+				expect( exists ).toBeTypeOf("boolean");
+			});
+
+			it( "can insert/update new pokemon to database", function() {
+        var requestResult = model.getPokemonProperties(35);
+				var exists = model.checkExist(35);
+        if(requestResult)
+        {
+          if( exists )
+          {
+            model.updatePokemon();
+          }
+          else
+          {
+            model.insertPokemon();
+          }
+        }
+				expect( exists ).toBeTypeOf("boolean");
+			});
+
+      story( "I want to call the api with a pokemon id", function() {
+				given( "a valid pokemon id", function() {
+					then( "I will be receive a response with message and pokemon details", function() {
+            var requestResult = model.getPokemonProperties(35);
+            var exists = model.checkExist(35);
+            if(requestResult)
+            {
+              if( exists )
+              {
+                model.updatePokemon();
+              }
+              else
+              {
+                model.insertPokemon();
+              }
+            }
+
+						var response = model.getResponse();
+						expect( response ).toHaveKey("pokemon");
+					} );
+				} );
+				given( "invalid pokemon id", function() {
+					then( "I will receive a message with Not Found ", function() {
+            var pokemon = model.getPokemonProperties( "Rdasf" );
+            var response = model.getResponse();
+            expect( response.message ).toBe("No result found");
+					} );
+				} );
+			} );
+		});
+	}
+
+}


### PR DESCRIPTION
Created new CFC: Pokemon.cfc under /models to replace functions done by previous code pokemon.cfm. 

Updated /handlers/CupidPokemon.cfc
- removed include of pokemon.cfm
- called component Pokemon.cfc, called getPokemonProperties and passed the pokemon id, will return a value if id exist in poke api or not
- with previous code, it creates an error if pokemon id already exists in the database, so theres another checking checkExists to tell wether to INSERT new data or UPDATE existing
- call getResponse to get response, will return "No result found" if no data has been found, and will return pokemon data if found

Created /test/specs/integration/PokemonTest.cfc for unit/integration test for Pokemon.cfc
